### PR TITLE
add private rosdep file

### DIFF
--- a/rosdep/private.yaml
+++ b/rosdep/private.yaml
@@ -1,0 +1,6 @@
+ur_robot_driver:
+  ubuntu: ros-melodic-ur-robot-driver
+ur_description:
+  ubuntu: ros-melodic-ur-description
+ur_e_description:
+  ubuntu: ros-melodic-ur-e-description


### PR DESCRIPTION
This is needed to simplify the rosdep step for these symbols that don't exist in the public rosdep.